### PR TITLE
Introduce map reroll

### DIFF
--- a/maps/biter_battles_v2/difficulty_vote.lua
+++ b/maps/biter_battles_v2/difficulty_vote.lua
@@ -114,11 +114,47 @@ local function on_player_left_game(event)
 	set_difficulty()
 end
 
+local function set_reroll_map_voting_status(player)
+	local yes = 0
+	local no = 0
+	for _, players in pairs(global.reroll_map_voting) do
+		if players == 1 then 
+			yes = yes + 1
+		else 
+			no = no + 1
+		end
+	end
+	local result = math.floor( yes / ( yes + no ) )
+	if result > 0.75 then
+		global.reroll_map_voting_status = true
+	else
+		global.reroll_map_voting_status = false
+	end
+	local reroll_time_left = math.floor((global.reroll_time_limit - game.ticks_played)/60)
+	game.print(result*100 .. "% votes to reroll." .. " Need 75% to reroll map.".. " Time left " .. reroll_time_left .. "s" )
+end
+
 local function on_gui_click(event)
 	if not event then return end
 	if not event.element then return end
 	if not event.element.valid then return end
+
 	local player = game.players[event.element.player_index]
+	if event.element.name == "reroll_yes" then 
+		if global.reroll_map_voting[player.name] ~= 1 then 
+			global.reroll_map_voting[player.name] = 1 
+			game.print(player.name .. " want to reroll map ",{r = 0.1, g = 0.9, b = 0.0})	
+			set_reroll_map_voting_status(player)
+		end
+	end
+	if event.element.name == "reroll_no" then 
+		if global.reroll_map_voting[player.name] ~= 0 then 
+			global.reroll_map_voting[player.name] = 0
+			game.print(player.name .. " want to keep this map", {r = 0.9, g = 0.1, b = 0.1})
+			set_reroll_map_voting_status(player)
+		end		
+	end
+
 	if event.element.name == "difficulty_gui" then
 		poll_difficulty(player)
 		return

--- a/maps/biter_battles_v2/difficulty_vote.lua
+++ b/maps/biter_battles_v2/difficulty_vote.lua
@@ -124,14 +124,14 @@ local function set_reroll_map_voting_status(player)
 			no = no + 1
 		end
 	end
-	local result = math.floor( yes / ( yes + no ) )
-	if result > 0.75 then
+	local result = math.floor( yes / ( yes + no ) * 100)
+	if result > 75 then
 		global.reroll_map_voting_status = true
 	else
 		global.reroll_map_voting_status = false
 	end
 	local reroll_time_left = math.floor((global.reroll_time_limit - game.ticks_played)/60)
-	game.print(result*100 .. "% votes to reroll." .. " Need 75% to reroll map.".. " Time left " .. reroll_time_left .. "s" )
+	game.print(result .. "% votes to reroll." .. " Need 75% to reroll map.".. " Time left " .. reroll_time_left .. "s" )
 end
 
 local function on_gui_click(event)

--- a/maps/biter_battles_v2/game_over.lua
+++ b/maps/biter_battles_v2/game_over.lua
@@ -495,5 +495,30 @@ local function chat_with_everyone(event)
     game.forces[enemy].print(message, player.chat_color)
 end
 
+function Public.reroll_map()
+    game.print("Generated new map")
+    game.speed = 1
+    global.reroll_voting_status = false
+    local prev_surface = global.bb_surface_name
+    Special_games.reset_active_special_games()
+    Special_games.reset_special_games_variables()
+    Init.tables()
+    Init.playground_surface()
+    Init.forces()
+    Init.draw_structures()
+    Gui.reset_tables_gui()
+    Init.load_spawn()
+    for _, player in pairs(game.players) do
+        Functions.init_player(player)
+        for _, e in pairs(player.gui.left.children) do
+            e.destroy()
+        end
+        Gui.create_main_gui(player)
+    end
+    game.reset_time_played()
+    global.server_restart_timer = nil    
+    game.delete_surface(prev_surface)
+end
+
 Event.add(defines.events.on_console_chat, chat_with_everyone)
 return Public

--- a/maps/biter_battles_v2/gui.lua
+++ b/maps/biter_battles_v2/gui.lua
@@ -39,6 +39,24 @@ function Public.clear_copy_history(player)
 	end
 end
 
+function create_reroll_button(player)
+	if player.gui.top["reroll_yes"] then 
+		player.gui.top["reroll_yes"].destroy()
+		player.gui.top["reroll_no"].destroy()
+	end
+	if game.ticks_played < global.reroll_time_limit then
+		local b_reroll_yes = player.gui.top.add { type = "sprite-button", caption = "New map", name = "reroll_yes" }
+		b_reroll_yes.style.font = "heading-2"
+		b_reroll_yes.style.font_color = {r = 0.1, g = 0.9, b = 0.0}
+		gui_style(b_reroll_yes, {width = 150, height = 38})	
+	
+		local b_reroll_no = player.gui.top.add { type = "sprite-button", caption = "Keep this", name = "reroll_no" }
+		b_reroll_no.style.font = "heading-2"
+		b_reroll_no.style.font_color = {r = 0.9, g = 0.1, b = 0.1}
+		gui_style(b_reroll_no, {width = 150, height = 38})	
+	end
+end
+
 function Public.reset_tables_gui()
 	global.player_data_afk = {}
 end
@@ -286,6 +304,7 @@ end
 
 function Public.refresh()
 	for _, player in pairs(game.connected_players) do
+		create_reroll_button(player)
 		if player.gui.left["bb_main_gui"] then
 			Public.create_main_gui(player)
 		end

--- a/maps/biter_battles_v2/init.lua
+++ b/maps/biter_battles_v2/init.lua
@@ -112,6 +112,7 @@ function Public.initial_setup()
 	}
 	for _, d in pairs(defs) do p.set_allows_action(d, true) end
 
+	global.reroll_time_limit = 1800
 	global.gui_refresh_delay = 0
 	global.game_lobby_active = true
 	global.bb_debug = false
@@ -189,6 +190,8 @@ function Public.tables()
 		global.bb_surface_name = "bb0"
 	end
 
+	global.reroll_map_voting_status=false
+	global.reroll_map_voting = {}
 	global.bb_evolution = {}
 	global.bb_game_won_by_team = nil
 	global.bb_threat = {}

--- a/maps/biter_battles_v2/main.lua
+++ b/maps/biter_battles_v2/main.lua
@@ -156,6 +156,9 @@ local function on_tick()
 	if tick % 60 == 0 then 
 		global.bb_threat["north_biters"] = global.bb_threat["north_biters"] + global.bb_threat_income["north_biters"]
 		global.bb_threat["south_biters"] = global.bb_threat["south_biters"] + global.bb_threat_income["south_biters"]
+		if global.reroll_map_voting_status and game.ticks_played == global.reroll_time_limit then 
+		Game_over.reroll_map()		
+		end
 	end
 
 	if (tick+11) % 300 == 0 then


### PR DESCRIPTION
### Brief description of the changes:
Implementing feature approved by community.
https://discord.com/channels/823696400797138974/823771211421974579/980397648756490270
Players are able to vote to generate new map only within 30s from the start (game time / ticks_played).
It require approval from 75% of all voters to pass.
Map is generated or not at 30 s mark from the (game time / ticks_played).
Players are able to generate new map as many times as they want.


### Tested Changes:
- [x] I've tested the changes locally.
- [ ] I've not tested the changes.
